### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,20 +12,20 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -34,24 +34,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: lint"
-        run: |
-          pnpm run --if-present lint
+        run: pnpm run --if-present lint
 
   build:
     runs-on: ubuntu-latest
@@ -59,43 +57,37 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8.14
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Integration: lint build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present lint-build
+        run: pnpm run --if-present lint-build
 
       - name: "Continuous Integration: test build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present test-build
+        run: pnpm run --if-present test-build
 
       - name: "Retain build artifact: storybook"
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: storybook
           path: packages/storybook/dist/
@@ -107,24 +99,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: test"
-        run: |
-          pnpm run --if-present test
+        run: pnpm run --if-present test
 
   publish-website:
     runs-on: ubuntu-latest
@@ -133,16 +123,16 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: "Restore build artifact: Storybook"
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: storybook
           path: packages/storybook/dist/
 
       - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # v4.6.1
         with:
           branch: gh-pages
           folder: packages/storybook/dist/
@@ -154,27 +144,26 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: "Continuous Deployment: install"
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
       - name: "Continuous Deployment: build"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8.14
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
@@ -40,8 +38,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8.14
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
@@ -115,8 +111,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8.14
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
@@ -166,8 +160,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 8.14
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "private": true,
   "engines": {
-    "node": "^20 || ^21",
-    "pnpm": "^8 || ^9"
+    "node": "^20",
+    "pnpm": "^9"
   },
   "workspaces": [
     "./packages/*",
@@ -75,5 +75,6 @@
   },
   "dependencies": {
     "http-server": "14.1.1"
-  }
+  },
+  "packageManager": "pnpm@9.1.2+sha256.19c17528f9ca20bd442e4ca42f00f1b9808a9cb419383cd04ba32ef19322aba7"
 }


### PR DESCRIPTION
Update `package.json`:
  - Update "engines.pnpm" to only allow pnpm v9 because the lockfile version is not compatible with pnpm v8
  - Update "engines.node" to only allow Node.js 20 which is the current LTS version. Node.js v21 is no longer officially supported.
  - Add "packageManager" for use with Vercel as well as the "pnpm/action-setup"

Update `.github/workflows/continuous-deployment.yml`:
  - Remove "version" input from "pnpm/action-setup" because it will pick up the pnpm version from package.json#packageManager

Use hashes to pin GitHub Actions to prevent tampering. Tags are added ascomments. Dependabot will update both in pull requests.

Update all actions to their latest versions.

Make it explicit that `--frozen-lockfile` is used when running `pnpm install` in CI.