### PR TITLE
chore: update valid-values-license

### DIFF
--- a/npmpackagejsonlint.config.cjs
+++ b/npmpackagejsonlint.config.cjs
@@ -11,7 +11,7 @@ module.exports = {
     {
       patterns: ['proprietary/**/package.json'],
       rules: {
-        'valid-values-license': ['error', ['SEE LICENSE IN ../LICENSE.md']],
+        'valid-values-license': ['error', ['SEE LICENSE IN LICENSE.md']],
       },
     },
   ],

--- a/proprietary/LICENSE.md
+++ b/proprietary/LICENSE.md
@@ -1,7 +1,0 @@
-# License
-
-Copyright (c) {year} {author}. All rights reserved.
-
-The open source license does NOT apply to files in this directory.
-
-These are properietary assets to {author}.

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.0",
   "author": "Community for NL Design System",
   "description": "Assets",
-  "license": "SEE LICENSE IN ../LICENSE.md",
+  "license": "SEE LICENSE IN LICENSE.md",
   "name": "@tilburg/assets",
   "keywords": [
     "nl-design-system"

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.15",
   "author": "Community for NL Design System",
   "description": "Example design tokens",
-  "license": "SEE LICENSE IN ../LICENSE.md",
+  "license": "SEE LICENSE IN LICENSE.md",
   "name": "@tilburg/design-tokens",
   "keywords": [
     "nl-design-system"

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-alpha.0",
   "author": "Community for NL Design System",
   "description": "Font assets",
-  "license": "SEE LICENSE IN ../LICENSE.md",
+  "license": "SEE LICENSE IN LICENSE.md",
   "name": "@tilburg/font",
   "main": "dist/index.css",
   "keywords": [


### PR DESCRIPTION
`proprietary/*` packages need their own LICENSE.md so make sure their `package.json#license` is correct.

Remove the unneeded `proprietary/LICENSE.md`.