### PR TITLE
Changed color to make paragraph-lead (small) accessible

### DIFF
--- a/proprietary/design-tokens/figma/tilburg/figma.tokens.json
+++ b/proprietary/design-tokens/figma/tilburg/figma.tokens.json
@@ -4414,7 +4414,7 @@
         "lead": {
           "color": {
             "$type": "color",
-            "$value": "{tilburg.color.blue.300}"
+            "$value": "{tilburg.color.blue.400}"
           },
           "small-vw": {
             "font-size": {

--- a/proprietary/design-tokens/figma/tilburg/figma.tokens.json
+++ b/proprietary/design-tokens/figma/tilburg/figma.tokens.json
@@ -4414,7 +4414,7 @@
         "lead": {
           "color": {
             "$type": "color",
-            "$value": "{utrecht.document.color}"
+            "$value": "{tilburg.color.blue.300}"
           },
           "small-vw": {
             "font-size": {


### PR DESCRIPTION
Changed paragraph-lead color from {tilburg.color.blue.300} (3.10:1 contrast) to {tilburg.color.blue.400} (6.36:1 contrast), to make paragraph-lead small accessible according to WCAG 2.2 AA.