### PR TITLE
chore: ensure packages are published with provenance

### DIFF
--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -9,7 +9,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",


### PR DESCRIPTION
Adding it to package.json to doubly ensure it is true, so you don't have to rely only on .npmrc
